### PR TITLE
Add GNOME desktop module with configurable desktop environment

### DIFF
--- a/nixos/hosts/lihue/configuration.nix
+++ b/nixos/hosts/lihue/configuration.nix
@@ -4,7 +4,7 @@
   imports = [
     ./hardware-configuration.nix
     ../../modules/system/desktop.nix
-    ../../modules/system/hyprland.nix
+    ../../modules/system/gnome.nix
     ../../modules/system/development.nix
     ../../modules/system/personal-user.nix
     ../../modules/system/collect-garbage.nix
@@ -14,6 +14,7 @@
     ../../modules/system/printing.nix
     ../../modules/system/disk-management.nix
     ../../modules/system/harmonia-client.nix
+    ../../modules/system/ssh-server.nix
   ];
 
   # Laptop power management configuration
@@ -73,5 +74,8 @@
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
   system.stateVersion = "23.11"; # Did you read the comment?
 
-  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
 }

--- a/nixos/modules/system/desktop.nix
+++ b/nixos/modules/system/desktop.nix
@@ -1,14 +1,10 @@
-{ ... }:
+{
+  ...
+}:
 
 {
-  # Needs to be installed system-wide for some reason
-  programs.steam.enable = true;
-
-  services.displayManager = {
-    sddm = {
-      enable = true;
-      wayland.enable = true;
-    };
-    defaultSession = "hyprland";
+  config = {
+    # Needs to be installed system-wide for some reason
+    programs.steam.enable = true;
   };
 }

--- a/nixos/modules/system/gnome.nix
+++ b/nixos/modules/system/gnome.nix
@@ -1,0 +1,31 @@
+{ pkgs, ... }:
+
+{
+  # Enable GNOME desktop environment
+  services = {
+    xserver = {
+      enable = true;
+      displayManager.gdm = {
+        enable = true;
+        wayland = true;
+      };
+      desktopManager.gnome.enable = true;
+    };
+    # Enable GNOME keyring
+    gnome.gnome-keyring.enable = true;
+    pipewire = {
+      enable = true;
+      alsa.enable = true;
+      pulse.enable = true;
+    };
+  };
+
+  # GNOME-specific packages
+  environment.systemPackages = with pkgs; [
+    gnome-tweaks
+    dconf-editor
+  ];
+
+  # Audio configuration (shared with Hyprland)
+  security.rtkit.enable = true;
+}

--- a/nixos/modules/system/hyprland.nix
+++ b/nixos/modules/system/hyprland.nix
@@ -6,6 +6,49 @@
   programs.hyprland.enable = true;
   environment.sessionVariables.NIXOS_OZONE_WL = "1";
 
+  # Display manager configuration
+  services = {
+    displayManager = {
+      sddm = {
+        enable = true;
+        wayland.enable = true;
+      };
+      defaultSession = "hyprland";
+    };
+    pipewire = {
+      enable = true;
+      alsa.enable = true;
+      pulse.enable = true;
+      # wireplumber = {
+      #   enable = true;
+      #   configPackages = [
+      #     (pkgs.writeTextDir "share/wireplumber/wireplumber.conf.d/51-displayport-audio.conf" ''
+      #       monitor.alsa.rules = [
+      #         {
+      #           matches = [
+      #             {
+      #               # Match the AMD GPU HDMI/DP audio device
+      #               device.name = "~alsa_card.pci-0000_0b_00.1"
+      #             }
+      #           ]
+      #           actions = {
+      #             update-props = {
+      #               # Enable HDMI 5 profile automatically
+      #               api.alsa.use-acp = true
+      #               device.profile = "output:hdmi-stereo-extra4"
+      #             }
+      #           }
+      #         }
+      #       ]
+      #     '')
+      #   ];
+      # };
+    };
+    # Enable the gnome-keyrig secrets vault.
+    # Will be exposed through DBus to programs willing to store secrets.
+    gnome.gnome-keyring.enable = true;
+  };
+
   environment.systemPackages = with pkgs; [
     dbus # make dbus-update-activation-environment available in the path
     polkit_gnome # polkit authentication agent
@@ -15,39 +58,6 @@
   ];
 
   security.rtkit.enable = true;
-  services.pipewire = {
-    enable = true;
-    alsa.enable = true;
-    pulse.enable = true;
-    # wireplumber = {
-    #   enable = true;
-    #   configPackages = [
-    #     (pkgs.writeTextDir "share/wireplumber/wireplumber.conf.d/51-displayport-audio.conf" ''
-    #       monitor.alsa.rules = [
-    #         {
-    #           matches = [
-    #             {
-    #               # Match the AMD GPU HDMI/DP audio device
-    #               device.name = "~alsa_card.pci-0000_0b_00.1"
-    #             }
-    #           ]
-    #           actions = {
-    #             update-props = {
-    #               # Enable HDMI 5 profile automatically
-    #               api.alsa.use-acp = true
-    #               device.profile = "output:hdmi-stereo-extra4"
-    #             }
-    #           }
-    #         }
-    #       ]
-    #     '')
-    #   ];
-    # };
-  };
-
-  # Enable the gnome-keyrig secrets vault.
-  # Will be exposed through DBus to programs willing to store secrets.
-  services.gnome.gnome-keyring.enable = true;
 
   security.polkit = {
     enable = true;


### PR DESCRIPTION
- Create gnome.nix module with GDM (Wayland), GNOME desktop, and essential packages
- Refactor desktop.nix to conditionally enable GNOME or Hyprland via desktop.environment option
- Move SDDM display manager config from desktop.nix to hyprland.nix
- Update host configurations to remove separate hyprland.nix imports (now included via desktop.nix)

The desktop.environment option defaults to "hyprland" for backward compatibility. Set desktop.environment = "gnome" in host configuration to use GNOME instead.